### PR TITLE
Fix custom log generated without a configuration file

### DIFF
--- a/src/reportmodifier/ReportModifier.py
+++ b/src/reportmodifier/ReportModifier.py
@@ -139,7 +139,7 @@ class ReportModifier:
         basic_config.yaml-file must be stored in ./tests folder
         """
         self._execution_result.visit(self._modifier)
-        if self._modifier.report_configuration is not None:
+        if self._modifier.config_found:
             ResultWriter(self._execution_result).write_results(
                 outputdir=self._result_dir,
                 log=f"{self._modifier.report_name}.html",

--- a/src/reportmodifier/ReportModifierVisitor.py
+++ b/src/reportmodifier/ReportModifierVisitor.py
@@ -25,6 +25,11 @@ class ReportModifierVisitor(ResultVisitor):
         self._keyword_path = None
         self.__root = None
         self._tests = []
+        self._config_found = False
+
+    @property
+    def config_found(self) -> bool:
+        return self._config_found
 
     @property
     def report_name(self):
@@ -73,6 +78,7 @@ class ReportModifierVisitor(ResultVisitor):
                     return False
                 path = list(configuration_path.values())[0]
                 logger.info(f"Found log configuration of fest: {test.name}: {tag} {path}")
+                self._config_found = True
                 if report_configuration.lower() == "basic_config":
                     self.basic_configuration = ReportConfiguration(path)
                 else:

--- a/src/reportmodifier/_report_configuration.py
+++ b/src/reportmodifier/_report_configuration.py
@@ -14,6 +14,9 @@ class ReportConfiguration:
         self.__keyword_names_as_info = None
         self.__keyword_as_structure = None
 
+    def __bool__(self) -> bool:
+        return self.__path is not None
+
     def __config(self) -> Dict:
         if self.__path is None:
             self.__yaml_config = {}

--- a/tests/utests/test_report_configuration/test_report_configuration.py
+++ b/tests/utests/test_report_configuration/test_report_configuration.py
@@ -49,6 +49,12 @@ class TestReportConfiguration(unittest.TestCase):
         self.assertEqual(1, len(self.report.keyword_as_structure))  # noqa: PT009
         self.assertEqual(self.report.keyword_as_structure[0].name, "Keyword Zum Zusammenklappen")  # noqa: PT009
 
+    def test_bool_is_false_without_config_file(self) -> None:
+        self.assertFalse(bool(ReportConfiguration(None)))
+
+    def test_bool_is_true_with_config_file(self) -> None:
+        self.assertTrue(bool(self.report))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem
The custom log is generated even when the YAML configuration referenced by the
`report:` / `fb_report:` tag does not exist.

### Cause
`ReportConfiguration` is initialized as an object (never `None`) and has no
`__bool__`, so the guard in `ReportModifier.write_report`
(`if report_configuration is not None`) is always `True`.

### Fix
- add `__bool__` to `ReportConfiguration` (falsy when no file was loaded)
- track a `config_found` flag in the visitor, set once any test loads an existing config file
- `write_report` checks `config_found` instead of `is not None`

### Testing
- added unit tests for `ReportConfiguration.__bool__`
- manual run with the listener: missing config -> no custom log; existing config -> custom log still written
