### PR TITLE
Ignore failures swallowed by wrapper keywords in the report

### DIFF
--- a/src/reportmodifier/ReportModifierVisitor.py
+++ b/src/reportmodifier/ReportModifierVisitor.py
@@ -150,6 +150,10 @@ class ReportModifierVisitor(ResultVisitor):
     def start_message(self, msg: Message):
         if self.report_configuration or self.basic_configuration:
             last_message = _get_last_message(self._relevant_messages[self._keyword])
+            if _message_is_under_ignored_keyword(
+                msg, self.report_configuration.ignored_keywords + self.basic_configuration.ignored_keywords
+            ):
+                return
             if _message_content_is_relevant(
                 msg.message,
                 self.report_configuration,
@@ -160,6 +164,8 @@ class ReportModifierVisitor(ResultVisitor):
                 self._relevant_keyword_calls.append(_get_keyword_call_path(msg.parent))
             if _message_status_is_relevant(
                 msg.level, self.report_configuration.message_status + self.basic_configuration.message_status
+            ) and not _message_shall_be_ignored(
+                msg.message, self.report_configuration, self.basic_configuration, last_message
             ):
                 self._relevant_messages[self._keyword].append(msg)
                 self._relevant_keyword_calls.append(_get_keyword_call_path(msg.parent))
@@ -295,3 +301,10 @@ def _message_status_is_relevant(message_level: str, relevant_levels: list):
         relevant_levels (lsit): List with accepted levels
     """
     return message_level.lower() in [r.lower() for r in relevant_levels]
+
+
+def _message_is_under_ignored_keyword(msg, ignored_keywords):
+    if not ignored_keywords:
+        return False
+    keyword_path = _get_keyword_call_path(msg.parent)
+    return any(name.lower() in keyword_path.lower() for name in ignored_keywords)

--- a/src/reportmodifier/_report_configuration.py
+++ b/src/reportmodifier/_report_configuration.py
@@ -11,6 +11,7 @@ class ReportConfiguration:
         self.__keywords = None
         self.__messages = None
         self.__ignored_messages = None
+        self.__ignored_keywords = None
         self.__keyword_names_as_info = None
         self.__keyword_as_structure = None
 
@@ -80,6 +81,15 @@ class ReportConfiguration:
     def ignored_messages(self) -> List:
         self.ignored_message_pattern  # noqa: B018
         return [c.text for c in self._ignored_message_configs() if c.text is not None]
+
+    @property
+    def ignored_keywords(self) -> List:
+        if self.__ignored_keywords is None:
+            self.__ignored_keywords = []
+            keywords = self.__config().get("ignored_keywords")
+            if keywords is not None:
+                self.__ignored_keywords = list(keywords)
+        return self.__ignored_keywords
 
     @property
     def names_as_info(self) -> List:

--- a/tests/utests/test_report_configuration/configuration.yaml
+++ b/tests/utests/test_report_configuration/configuration.yaml
@@ -17,3 +17,6 @@ messages:
 keyword_name_as_info:
  - Keyword Name As Info
  - Second Keyword As Info
+ignored_keywords:
+ - Run Keyword And Ignore Error
+ - Run Keyword And Return Status

--- a/tests/utests/test_report_configuration/test_report_configuration.py
+++ b/tests/utests/test_report_configuration/test_report_configuration.py
@@ -45,6 +45,12 @@ class TestReportConfiguration(unittest.TestCase):
         pattern = self.report.message_text
         self.assertListEqual(pattern, ["Relevanter Text"])
 
+    def test_ignored_keywords(self) -> None:
+        self.assertListEqual(
+            self.report.ignored_keywords,
+            ["Run Keyword And Ignore Error", "Run Keyword And Return Status"],
+        )
+
     def test_keyword_name_as_structure(self) -> None:
         self.assertEqual(1, len(self.report.keyword_as_structure))  # noqa: PT009
         self.assertEqual(self.report.keyword_as_structure[0].name, "Keyword Zum Zusammenklappen")  # noqa: PT009

--- a/tests/utests/test_report_modifier/test_message_is_under_ignored_keyword.py
+++ b/tests/utests/test_report_modifier/test_message_is_under_ignored_keyword.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest import mock
+
+from src.reportmodifier.ReportModifierVisitor import _message_is_under_ignored_keyword
+
+
+class TestMessageIsUnderIgnoredKeyword(unittest.TestCase):
+    def setUp(self):
+        self.msg = mock.MagicMock()
+
+    def test_no_ignored_keywords(self):
+        self.assertFalse(_message_is_under_ignored_keyword(self.msg, []))
+
+    def test_message_is_under_ignored_keyword(self):
+        with mock.patch(
+            "src.reportmodifier.ReportModifierVisitor._get_keyword_call_path",
+            return_value="Test.Run Keyword And Ignore Error.Fail",
+        ):
+            self.assertTrue(_message_is_under_ignored_keyword(self.msg, ["Run Keyword And Ignore Error"]))
+
+    def test_message_is_not_under_ignored_keyword(self):
+        with mock.patch(
+            "src.reportmodifier.ReportModifierVisitor._get_keyword_call_path",
+            return_value="Test.Some Keyword.Log",
+        ):
+            self.assertFalse(_message_is_under_ignored_keyword(self.msg, ["Run Keyword And Ignore Error"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem
With `messages: - status: FAIL`, the report also collects failures that are caught at
runtime (e.g. via `Run Keyword And Return Status` / `Run Keyword And Ignore Error`).
The test passes, but the swallowed failures still show up in the report, and
`ignored_messages` cannot filter them out.

### Cause
In `start_message` the status-based collection appends the message purely by its level
and never consults the ignore logic or the surrounding keyword.

### Fix
- new `ignored_keywords` option: messages logged under one of the listed keywords are
  dropped (covers the failure-swallowing wrappers)
- status-matched messages now also run through the existing ignore filter, so
  `ignored_messages` (text/pattern) applies to FAIL messages too

### Testing
- unit tests for the config option and the new helper
- manual run: caught failures under the listed keywords are gone, genuine failures and
  other relevant messages remain
