### PR TITLE
Make the configuration source path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The high complexity of tests and the amount of information that can be logged ma
 
 ## Configuration assignment
 
-The report is configured using YAML files. The YAML files must be saved within the /tests folder. The name of the file to be used must be stored as a "report:" tag on the test case - either as a test tag for all test cases in the file or as a tag for a specific test case. There is also the option of a base configuration for all test cases using tag "report:basic_config" with file "basic_config.yaml" withing the /test directory. Examples:
+The report is configured using YAML files. By default the YAML files are looked up within the /tests folder of the test source path. The name of the file to be used must be stored as a "report:" tag on the test case - either as a test tag for all test cases in the file or as a tag for a specific test case. There is also the option of a base configuration for all test cases using tag "report:basic_config" with file "basic_config.yaml" withing the /test directory. Examples:
 ```shell
 *** Settings ***
 
@@ -99,3 +99,18 @@ ReportModifier(basis_output_xml, result_dir, report_name).write_report()
 ```
 
 or using the listener "ReportModifierListener" which is a Listener V3. In this case, the source xml file is the current created xml file, result dir the current result dir and report name the configured tag name.
+
+## Configuration source path
+
+By default the configuration files are searched below the "tests" folder derived from the test source path. To keep the configuration generic across different test suites or repositories, the source path can be set explicitly.
+
+Using the class, pass the optional *config_dir* parameter:
+```shell
+ReportModifier(basis_output_xml, result_dir, config_dir="path/to/configs").write_report()
+```
+
+Using the listener, pass the directory as listener argument:
+```shell
+robot --listener ReportModifierListener:path/to/configs tests
+```
+If *config_dir* is omitted, the previous behaviour applies (lookup within the "tests" folder).

--- a/src/ReportModifierListener/ReportModifierListener.py
+++ b/src/ReportModifierListener/ReportModifierListener.py
@@ -14,8 +14,9 @@ class ReportModifierListener:
     ROBOT_LISTENER_API_VERSION = 3
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
-    def __init__(self) -> None:
+    def __init__(self, config_dir: Optional[str] = None) -> None:
         self._output_file: Optional[str] = None
+        self._config_dir = config_dir
 
     @not_keyword
     def output_file(self, path: str) -> None:
@@ -25,4 +26,6 @@ class ReportModifierListener:
         if self._output_file is None:
             failure_msg = "Output file is not set."
             raise TypeError(failure_msg)
-        ReportModifier(self._output_file, self._output_file.parent).write_report()
+        ReportModifier(
+            self._output_file, self._output_file.parent, config_dir=self._config_dir
+        ).write_report()

--- a/src/reportmodifier/ReportModifier.py
+++ b/src/reportmodifier/ReportModifier.py
@@ -117,6 +117,7 @@ class ReportModifier:
         basis_output_xml: Union[Path, str],
         result_dir: Union[Path, str],
         report_name: str = "custom_log",
+        config_dir: Union[Path, str, None] = None,
     ):
         """Creates an additional log filtering the content based on yaml-configurations
 
@@ -124,10 +125,12 @@ class ReportModifier:
             basis_output_xml (Union[Path, str]): path for the source xml file
             result_dir (Union[Path, str]): output dir path where to store the new report
             report_name (str): optionally, target report name
+            config_dir (Union[Path, str, None]): optionally, the directory to search the
+                yaml configuration files in. Defaults to the "tests" folder in the test source path.
         """
         self._basis_output_xml = basis_output_xml
         self._result_dir = result_dir
-        self._modifier = ReportModifierVisitor()
+        self._modifier = ReportModifierVisitor(config_dir)
         self._modifier.report_name = report_name
         self._execution_result = ExecutionResult(self._basis_output_xml)
 

--- a/src/reportmodifier/ReportModifierVisitor.py
+++ b/src/reportmodifier/ReportModifierVisitor.py
@@ -13,8 +13,9 @@ from ._report_configuration import ReportConfiguration
 
 
 class ReportModifierVisitor(ResultVisitor):
-    def __init__(self) -> None:
+    def __init__(self, config_dir: str | Path | None = None) -> None:
         super().__init__()
+        self._config_dir = Path(config_dir) if config_dir else None
         self.report_configuration = ReportConfiguration(None)
         self.basic_configuration = ReportConfiguration(None)
         self.__report_name = None
@@ -58,10 +59,15 @@ class ReportModifierVisitor(ResultVisitor):
             if tag.startswith(("fb_report:", "report:")):
                 report_configuration = tag.split("report:")[-1].strip()
                 report_configuration = report_configuration.lower().replace(".yaml", "")
-                test_path = Path(test.source)
-                test_dir = Path(*test_path.parts[0 : test_path.parts.index("tests") + 1])
+                config_dir = self._config_dir or _default_config_dir(test.source)
+                if config_dir is None:
+                    logger.error(
+                        f'Could not locate a configuration directory for test {test.name}. '
+                        f'Pass config_dir or place the test below a "tests" folder.',
+                    )
+                    return False
                 configuration_path = get_files_in_folder(
-                    top_level_dir=test_dir,
+                    top_level_dir=config_dir,
                     condition_callback=lambda p: Path(p).stem.lower() == report_configuration  # noqa: B023
                     and Path(p).suffix == ".yaml",
                     recursive=True,
@@ -166,6 +172,15 @@ class ReportModifierVisitor(ResultVisitor):
 
     def end_message(self, msg: Message):
         pass
+
+
+def _default_config_dir(test_source):
+    if test_source is None:
+        return None
+    test_path = Path(test_source)
+    if "tests" not in test_path.parts:
+        return None
+    return Path(*test_path.parts[0 : test_path.parts.index("tests") + 1])
 
 
 def _get_all_submessages(keywords__, submessages_):

--- a/tests/utests/test_report_modifier/test_default_config_dir.py
+++ b/tests/utests/test_report_modifier/test_default_config_dir.py
@@ -1,0 +1,25 @@
+import unittest
+from pathlib import Path
+
+from src.reportmodifier.ReportModifierVisitor import _default_config_dir
+
+
+class TestDefaultConfigDir(unittest.TestCase):
+    def test_returns_tests_folder(self):
+        source = Path("C:/repo/tests/atests/suite.robot")
+        self.assertEqual(_default_config_dir(source), Path("C:/repo/tests"))
+
+    def test_uses_first_tests_folder(self):
+        source = Path("/home/user/tests/nested/tests/suite.robot")
+        self.assertEqual(_default_config_dir(source), Path("/home/user/tests"))
+
+    def test_returns_none_without_tests_folder(self):
+        source = Path("/home/user/suites/suite.robot")
+        self.assertIsNone(_default_config_dir(source))
+
+    def test_returns_none_for_missing_source(self):
+        self.assertIsNone(_default_config_dir(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem
The yaml configuration files had to be located below a folder literally named
`tests`, which was derived from the test source path. If the test was not below
such a folder, `Path.parts.index("tests")` raised a `ValueError`. This made it
impossible to keep the configuration generic and reuse it across different test
suites or repositories (issue #1).

### Fix
- add an optional `config_dir` to `ReportModifier`, `ReportModifierVisitor` and
  the `ReportModifierListener`, so the configuration source path can be set
  explicitly
- when `config_dir` is omitted the previous behaviour applies (lookup within the
  `tests` folder), but the derivation is now fault-tolerant: a missing `tests`
  folder is logged as an error instead of raising

### Usage
Class: `ReportModifier(output_xml, result_dir, config_dir="path/to/configs")`
Listener: `robot --listener ReportModifierListener:path/to/configs tests`

### Testing
- unit tests for the new `_default_config_dir` helper
- manual run against a generated output.xml: default lookup and explicit
  `config_dir` both produce the custom log

Closes #1
